### PR TITLE
fix bug where mobile hero text rendered only 4px tall

### DIFF
--- a/src/assets/css/app.pcss
+++ b/src/assets/css/app.pcss
@@ -215,7 +215,6 @@ footer .social-links li + li {
 /* Utils */
 
 #hero-text {
-  font-size: 4rem;
   font-weight: 900;
 
   /* Gradient background */


### PR DESCRIPTION
my 11ty starter's / CSS framework's docs 404ing is probably a sign that I should rebuild my blog again 😔

https://github.com/equinusocio/xity-starter
https://github.com/equinusocio/native-elements